### PR TITLE
ci(deps): bump all GitHub Actions + trivy-action 0.35.0 (consolidates 7 dependabot PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       uses: dominikh/staticcheck-action@v1
       with:
         version: "latest"
-        install-go: false
+        install-go: true
 
     - name: Run tests
       run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
@@ -57,7 +57,7 @@ jobs:
       run: make test-coverage-report
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       if: matrix.go-version == '1.22.x'
       with:
         files: ./coverage.out
@@ -72,10 +72,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.22.x
         cache: true
@@ -92,7 +92,7 @@ jobs:
       run: make release
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: release-binaries
         path: certgen-*
@@ -106,10 +106,10 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.24.0
+      uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true
@@ -117,7 +117,7 @@ jobs:
         output: 'trivy-results.sarif'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
@@ -127,16 +127,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.22.x
         cache: true
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v9
       with:
         version: latest
         args: --timeout=5m

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,18 +25,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 1.22.x
         cache: true

--- a/pkg/pkcs12/pkcs12.go
+++ b/pkg/pkcs12/pkcs12.go
@@ -31,7 +31,7 @@ func (g *Generator) GeneratePKCS12(leafCert *x509.Certificate, leafKey *rsa.Priv
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	leafCertPath := filepath.Join(tempDir, "leaf.pem")
 	leafKeyPath := filepath.Join(tempDir, "leaf.key")

--- a/tests/fileio/fileio_test.go
+++ b/tests/fileio/fileio_test.go
@@ -65,7 +65,7 @@ func TestFileWriter_WriteFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	testData := []byte("test file content")
@@ -99,7 +99,7 @@ func TestFileWriter_WriteFile_CreateDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	testData := []byte("test content")
@@ -123,7 +123,7 @@ func TestFileWriter_WriteBase64File(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	base64Data := "VGVzdCBiYXNlNjQgZGF0YQ=="
@@ -157,7 +157,7 @@ func TestFileWriter_ReadFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	testData := []byte("test read content")
@@ -195,7 +195,7 @@ func TestFileWriter_FileExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	existingFile := filepath.Join(tempDir, "exists.txt")
@@ -261,7 +261,7 @@ func TestFileWriter_WriteFile_Permissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	fw := fileio.NewFileWriter("test.com")
 	testPath := filepath.Join(tempDir, "test_perms.txt")

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -19,7 +19,7 @@ func TestFullCertificateGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Change to temp directory
 	originalDir, _ := os.Getwd()
@@ -180,7 +180,7 @@ func TestMultipleDomainGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	// Change to temp directory
 	originalDir, _ := os.Getwd()
@@ -300,7 +300,7 @@ func TestErrorHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create temp dir: %v", err)
 		}
-		defer os.RemoveAll(readOnlyDir)
+		defer func() { _ = os.RemoveAll(readOnlyDir) }()
 
 		// Make directory read-only
 		if err := os.Chmod(readOnlyDir, 0555); err != nil {

--- a/tests/pkcs12/pkcs12_test.go
+++ b/tests/pkcs12/pkcs12_test.go
@@ -111,7 +111,7 @@ func TestGeneratePKCS12(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
+	defer func() { _ = os.Remove(tempFile.Name()) }()
 
 	if err := os.WriteFile(tempFile.Name(), pfxData, 0644); err != nil {
 		t.Fatalf("Failed to write PKCS#12 file: %v", err)


### PR DESCRIPTION
One PR replacing the six stale dependabot PRs (#3, #6, #7, #9, #10, #11) whose check runs had expired, plus the trivy bump done right:

- actions/checkout v4 -> v6
- actions/setup-go v5 -> v6
- actions/upload-artifact v4 -> v6
- codecov/codecov-action v4 -> v5
- github/codeql-action v3 -> v4
- golangci/golangci-lint-action v6 -> v9 (no .golangci.yml in repo, so no config-format break)
- aquasecurity/trivy-action 0.24.0 -> 0.35.0 - clears the critical CVE-2026-33634 alert (closed PR #5 only went to 0.33.1, which is still vulnerable)